### PR TITLE
Hook/Transition.js + react transtion group. [V0.5]

### DIFF
--- a/joker/package.json
+++ b/joker/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^16.12.0",
     "react-icons": "^4.1.0",
     "react-responsive": "^8.2.0",
+    "react-transition-group": "^4.4.1",
     "tailwindcss": "^2.0.2"
   },
   "devDependencies": {

--- a/joker/src/components/Layout.tsx
+++ b/joker/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useState } from "react";
 import Head from "next/head";
 import * as AiIcons from "react-icons/ai";
 
+import Transition from "./hooks/Transition";
 import useBreakpoint from "./hooks/useBreakpoint";
 
 type Props = {
@@ -20,7 +21,15 @@ function Layout({ children, title = "Confin - Controle Financeiro" }: Props) {
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
 
-      {(isStatic || !isClosed) && (
+      <Transition
+        appear={false}
+        show={isStatic || !isClosed}
+        enter="transition-all duration-500"
+        enterFrom="-ml-64"
+        enterTo="ml-0"
+        leave="transition-all duration-500"
+        leaveTo="-ml-64"
+      >
         <aside className="bg-white w-64 min-h-screen flex flex-col">
           <div className="bg-white border-r border-b px-4 h-10 flex items-center">
             <span className="text-blue py-2"> Aplication </span>
@@ -48,7 +57,7 @@ function Layout({ children, title = "Confin - Controle Financeiro" }: Props) {
             </nav>
           </div>
         </aside>
-      )}
+      </Transition>
       <main className="flex-grow flex flex-col min-h-screen">
         <header className="bg-white border-b h-10 flex items-center justify-center">
           {!isStatic &&

--- a/joker/src/components/hooks/Transition.js
+++ b/joker/src/components/hooks/Transition.js
@@ -1,0 +1,115 @@
+/**
+ * Original source: https://gist.github.com/adamwathan/3b9f3ad1a285a2d1b482769aeb862467
+ * Author: Adam Wathan
+ *
+ * I modified the script to not remove the enterTo and leaveTo classes upon completing the transition
+ * Instead they're removed when the opposite transition begins
+ */
+import { CSSTransition as ReactCSSTransition } from "react-transition-group";
+import * as React from "react";
+
+const TransitionContext = React.createContext({
+  parent: {},
+});
+
+function useIsInitialRender() {
+  const isInitialRender = React.useRef(true);
+  React.useEffect(() => {
+    isInitialRender.current = false;
+  }, []);
+  return isInitialRender.current;
+}
+
+function CSSTransition({
+  show,
+  enter = "",
+  enterFrom = "",
+  enterTo = "",
+  leave = "",
+  leaveFrom = "",
+  leaveTo = "",
+  appear,
+  children,
+}) {
+  const enterClasses = enter.split(" ").filter((s) => s.length);
+  const enterFromClasses = enterFrom.split(" ").filter((s) => s.length);
+  const enterToClasses = enterTo.split(" ").filter((s) => s.length);
+  const leaveClasses = leave.split(" ").filter((s) => s.length);
+  const leaveFromClasses = leaveFrom.split(" ").filter((s) => s.length);
+  const leaveToClasses = leaveTo.split(" ").filter((s) => s.length);
+
+  function addClasses(node, classes) {
+    classes.length && node.classList.add(...classes);
+  }
+
+  function removeClasses(node, classes) {
+    classes.length && node.classList.remove(...classes);
+  }
+
+  return (
+    <ReactCSSTransition
+      appear={appear}
+      unmountOnExit
+      in={show}
+      addEndListener={(node, done) => {
+        node.addEventListener("transitionend", done, false);
+      }}
+      onEnter={(node) => {
+        removeClasses(node, [...leaveToClasses]);
+        addClasses(node, [...enterClasses, ...enterFromClasses]);
+      }}
+      onEntering={(node) => {
+        removeClasses(node, [...enterFromClasses]);
+        addClasses(node, [...enterToClasses]);
+      }}
+      onEntered={(node) => {
+        removeClasses(node, [...enterClasses]);
+      }}
+      onExit={(node) => {
+        removeClasses(node, [...enterToClasses]);
+        addClasses(node, [...leaveClasses, ...leaveFromClasses]);
+      }}
+      onExiting={(node) => {
+        removeClasses(node, [...leaveFromClasses]);
+        addClasses(node, [...leaveToClasses]);
+      }}
+      onExited={(node) => {
+        removeClasses(node, [...leaveClasses]);
+      }}
+    >
+      {children}
+    </ReactCSSTransition>
+  );
+}
+
+function Transition({ show, appear, ...rest }) {
+  const { parent } = React.useContext(TransitionContext);
+  const isInitialRender = useIsInitialRender();
+  const isChild = show === undefined;
+
+  if (isChild) {
+    return (
+      <CSSTransition
+        appear={parent.appear || !parent.isInitialRender}
+        show={parent.show}
+        {...rest}
+      />
+    );
+  }
+
+  return (
+    <TransitionContext.Provider
+      value={{
+        parent: {
+          show,
+          isInitialRender,
+          appear,
+        },
+      }}
+    >
+      <CSSTransition appear={appear} show={show} {...rest} />
+    </TransitionContext.Provider>
+  );
+}
+
+export default Transition;

--- a/joker/yarn.lock
+++ b/joker/yarn.lock
@@ -74,7 +74,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@7.12.5":
+"@babel/runtime@7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1391,6 +1391,14 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dom-helpers@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
+  integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@1.1.0:
   version "1.1.0"
@@ -3332,6 +3340,16 @@ react-responsive@^8.2.0:
     matchmediaquery "^0.3.0"
     prop-types "^15.6.1"
     shallow-equal "^1.1.0"
+
+react-transition-group@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.12.0:
   version "16.14.0"


### PR DESCRIPTION
Adicionado um novo Hook de transitions:
Biblioteca externa que facilita o uso de Transições no Tailwind.
Instalado a extensão react-transtion-group, para o funcionamento do Hook.


Adicionado o uso da transição no abrir e fechar do Sidebar.